### PR TITLE
ci: harden the release workflow against unauthorized publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+# Never run two publishes at once.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write # required for npm provenance
@@ -13,14 +18,37 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    # Manual approval gate: the `release` environment must require reviewers and
+    # holds NPM_TOKEN, so a pushed tag cannot publish without a human approving
+    # the deployment, and no other workflow run can read the token.
+    environment: release
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need history to prove the tag is on main
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
+
+      # Refuse to publish a tag that isn't reachable from main (i.e. code that
+      # didn't go through a reviewed PR) or whose name doesn't match the version.
+      - name: Guard — tag must be on main and match package.json
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo "::error::Refusing to publish — ${GITHUB_REF_NAME} is not on main."
+            exit 1
+          fi
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "v${PKG}" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match package.json (v${PKG})."
+            exit 1
+          fi
+          echo "Guard passed: ${GITHUB_REF_NAME} is on main and matches v${PKG}."
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check
       - name: Publish


### PR DESCRIPTION
Defense-in-depth so a pushed tag can't publish arbitrary/vulnerable code:

- Require a `release` GitHub Environment (manual approval + isolates NPM_TOKEN so no other workflow run can read it).
- Guard: refuse to publish unless the tagged commit is reachable from `main` (i.e. went through a reviewed PR) and the tag matches package.json version.
- Add release concurrency and fetch full history for the ancestor check.

### Title

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- - [ ] I have read the **CONTRIBUTING** document. -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Screenshots

<!--- Go ahead and add screenshots to your PR if it is applicable. --->
