### PR TITLE
ci: auto-create a GitHub Release on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write # create the GitHub Release for the tag
   id-token: write # required for npm provenance
 
 jobs:
@@ -55,3 +55,11 @@ jobs:
         run: pnpm publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Only runs if the publish above succeeded. Cuts a GitHub Release for the
+      # tag with auto-generated notes and marks it the latest.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          make_latest: true


### PR DESCRIPTION
After a successful npm publish, cut a GitHub Release for the tag with auto-generated notes and mark it latest (softprops/action-gh-release@v3, Node 24 runtime). Bumps the job permission to contents: write.

### Title

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- - [ ] I have read the **CONTRIBUTING** document. -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Screenshots

<!--- Go ahead and add screenshots to your PR if it is applicable. --->
