### PR TITLE
ci: add a manual publish fallback to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  # Manual fallback: publish the current main version on demand. Needed to
+  # recover when an automated publish fails — re-running the push-triggered run
+  # won't work, because release-please only sets `release_created` once (on the
+  # push that merges the release PR).
+  workflow_dispatch: {}
 
 concurrency:
   group: release-${{ github.ref }}
@@ -14,6 +19,7 @@ jobs:
   # the git tag and the GitHub Release, and flips `release_created` to true.
   release-please:
     name: Prepare release
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # release commits, tags, GitHub Releases
@@ -25,12 +31,13 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: rp
 
-  # Only runs when a release was just cut. Publishes to npm behind the
-  # manual-approval `release` environment, which also isolates NPM_TOKEN.
+  # Publishes to npm behind the manual-approval `release` environment (which also
+  # isolates NPM_TOKEN). Runs when release-please just cut a release, OR on a
+  # manual `workflow_dispatch` (the recovery path).
   publish:
     name: Publish to npm
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
Add `workflow_dispatch` so the publish job can be triggered on demand, and gate release-please to push events only. This recovers the case where an automated publish fails: re-running the push run won't help because release-please only emits `release_created` on the release-PR merge, so a manual dispatch is the way to publish the current main version. Still gated by the `release` environment.

### Title

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- - [ ] I have read the **CONTRIBUTING** document. -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Screenshots

<!--- Go ahead and add screenshots to your PR if it is applicable. --->
