### PR TITLE
ci: filter CodeQL's password-hash false positive on HMAC signing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,17 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          # This package is an API client with no password storage. Its only
+          # cryptographic hash is the HMAC-SHA256 request *signature* the Withings
+          # API mandates (src/core/crypto.ts) — which CodeQL misreads as insecure
+          # password hashing. Exclude that single query; it can only ever
+          # false-positive here. Everything else in security-and-quality runs.
+          config: |
+            queries:
+              - uses: security-and-quality
+            query-filters:
+              - exclude:
+                  id: js/insufficient-password-hash
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
src/core/crypto.ts uses HMAC-SHA256 to sign requests as the Withings API requires; CodeQL's js/insufficient-password-hash misreads that as insecure password hashing (it follows a value through an `.oauth` accessor and flags the fast hash). This package stores no passwords, so that query can only ever false-positive here — exclude just it via query-filters; the rest of security-and-quality still runs. The signing algorithm is unchanged (and must be: the server verifies HMAC-SHA256).

### Title

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- - [ ] I have read the **CONTRIBUTING** document. -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Screenshots

<!--- Go ahead and add screenshots to your PR if it is applicable. --->
