### PR TITLE
fix(goals): normalize empty goals to an object

### DIFF
--- a/src/resources/goals.ts
+++ b/src/resources/goals.ts
@@ -1,16 +1,25 @@
 import { ENDPOINTS } from "../config/index.js";
 import type { RequestOptions } from "../types/index.js";
-import type { GoalsBody } from "../models/user.js";
+import type { Goals, GoalsBody } from "../models/user.js";
 import { Resource } from "./base.js";
+
+/** Shape Withings actually returns: `goals` is an object, or `[]` when empty. */
+type RawGoalsBody = Omit<GoalsBody, "goals"> & { goals: Goals | unknown[] };
 
 /** The user's configured goals (steps, sleep, weight). */
 export class GoalsResource extends Resource {
   /** Get the user's goals. */
-  get(options: RequestOptions = {}): Promise<GoalsBody> {
-    return this.authed<GoalsBody>(
+  async get(options: RequestOptions = {}): Promise<GoalsBody> {
+    const body = await this.authed<RawGoalsBody>(
       ENDPOINTS.user,
       { action: "getgoals" },
       options,
     );
+    // Withings returns `goals: []` for accounts with no goals set. Normalize it
+    // to an empty object so `body.goals` is always the documented shape.
+    return {
+      ...body,
+      goals: Array.isArray(body.goals) ? {} : body.goals,
+    };
   }
 }

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -213,6 +213,18 @@ describe("devices / goals", () => {
     expect(body.goals.steps).toBe(10000);
     expect(calls[0].params.get("action")).toBe("getgoals");
   });
+
+  it("goals.get normalizes an empty goals array to an object", async () => {
+    // Withings returns `goals: []` for accounts with no goals set.
+    const { fetch } = createMockFetch(
+      routeByAction({
+        getgoals: { json: { status: 0, body: { goals: [] } } },
+      }),
+    );
+    const body = await client(fetch).goals.get();
+    expect(Array.isArray(body.goals)).toBe(false);
+    expect(body.goals).toEqual({});
+  });
 });
 
 describe("notify", () => {


### PR DESCRIPTION
Withings returns `goals: []` (an empty array) for accounts with no goals set, which doesn't match the documented object shape. Coerce it to `{}` so `goals.get()` always resolves `body.goals` as a `Goals` object, sparing callers an array/object check.

### Title

<!--- Provide a general summary of your changes in the Title above -->

### Description

<!--- Describe your changes in detail -->

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- - [ ] I have read the **CONTRIBUTING** document. -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Screenshots

<!--- Go ahead and add screenshots to your PR if it is applicable. --->
